### PR TITLE
Fix autoreconf misparsing ACLOCAL_AMFLAGS

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,6 +1,8 @@
 # Makefile.am - Top level automakefile for libuninameslist
 
-ACLOCAL_AMFLAGS = -I m4 $(ACLOCAL_FLAGS)
+# The braces around ACLOCAL_FLAGS below instead of parentheses are intentional!
+# Otherwise autoreconf misparses the line.
+ACLOCAL_AMFLAGS = -I m4 ${ACLOCAL_FLAGS}
 
 AM_CFLAGS = $(WCFLAGS) $(UN_CFLAGS)
 AM_LDFLAGS = $(WUNLIB) $(UN_LIB) -no-undefined


### PR DESCRIPTION
The braces around `${ACLOCAL_FLAGS}` were changed to parentheses in a previous commit. It makes autoreconf misparse the line and produce something like:
```
$ autoreconf -i
sh: ACLOCAL_FLAGS: command not found
```
The patch fixes the problem and adds a comment to prevent such problems in the future.