### PR TITLE
use new C functions for getting name2

### DIFF
--- a/buildnameslist.c
+++ b/buildnameslist.c
@@ -256,7 +256,7 @@ static int ReadNamesList(void) {
 	/* search for possible normalized aliases. Assume 1st annotation line */
 	for ( a_char=0; a_char<17*65536; ++a_char ) if ( uniannot[i][a_char]!=NULL ) {
 	    pt = uniannot[i][a_char];
-	    if ( *pt=='\t' && *++pt=='\%' && *++pt==' ' ) {
+	    if ( *pt=='\t' && *++pt=='%' && *++pt==' ' ) {
 		for ( j=-1; *pt!='\n' && *pt!='\0'; ++j,++pt );
 		if ( j>0 && j<128 ) {
 		    names2pt[i][a_char] = 3;


### PR DESCRIPTION
Requested at [comment of earlier superseded pull request](https://github.com/fontforge/libuninameslist/pull/11#issuecomment-359231722).

Includes minor fix by removing superfluous escape `\` for `%` mentioned [here in discussion on an earlier commit](https://github.com/fontforge/libuninameslist/commit/fcb62dac0e239c83025a8c0e9f6e56db8a073dae#r27133572).