### PR TITLE
tests: Remove .libs from linker paths.

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -3,11 +3,11 @@ AM_CPPFLAGS = -I$(top_srcdir) -I$(top_builddir)
 
 AM_CFLAGS = -I$(top_srcdir) -I$(top_builddir) $(DEP_CFLAGS) $(BABL_CFLAGS) -lm
 
-#DEPS = $(top_builddir)/.libs/libuninameslist.la
+#DEPS = $(top_builddir)/libuninameslist.la
 
 EXTRA_DIST = call-test.c
 
-LDADDS = $(top_builddir)/.libs/libuninameslist.la
+LDADDS = $(top_builddir)/libuninameslist.la
 
 # The tests
 noinst_PROGRAMS = call-test0 call-test1 call-test2
@@ -22,7 +22,7 @@ call_test2_SOURCES = call-test2.c
 call_test2_LDADD = $(LDADDS)
 
 if WANTLIBOFR
-LDADDF = $(top_builddir)/.libs/libuninameslist-fr.la
+LDADDF = $(top_builddir)/libuninameslist-fr.la
 
 call_test3_SOURCES = call-test3.c
 call_test3_LDADD = $(LDADDF)


### PR DESCRIPTION
When building libuninameslist with slibtool (https://dev.midipix.org/cross/slibtool) it fails.
```
rdlibtool --tag=CC --mode=link gcc -I.. -I.. -lm -g -O2 -o call-test0 call-test0.o ../.libs/libuninameslist.la

rdlibtool: lconf: {.name="libtool"}.
rdlibtool: fdcwd: {.fdcwd=AT_FDCWD, .realpath="/tmp/libuninameslist/tests"}.
rdlibtool: lconf: fstatat(AT_FDCWD,".",...) = 0 {.st_dev = 45, .st_ino = 168580}.
rdlibtool: lconf: openat(AT_FDCWD,"libtool",O_RDONLY,0) = -1 [ENOENT].
rdlibtool: lconf: openat(AT_FDCWD,"../",O_DIRECTORY,0) = 3.
rdlibtool: lconf: fstat(3,...) = 0 {.st_dev = 45, .st_ino = 168498}.
rdlibtool: lconf: openat(3,"libtool",O_RDONLY,0) = 4.
rdlibtool: lconf: found "/tmp/libuninameslist/libtool".
rdlibtool: error logged in slbt_get_deps_meta(), line 126: path not found: ../.libs/.libs/libuninameslist.a.slibtool.deps.
rdlibtool: < returned to > slbt_exec_link_create_executable(), line 1617.
rdlibtool: < returned to > slbt_exec_link(), line 2062.
make[1]: *** [Makefile:624: call-test0] Error 2
make[1]: Leaving directory '/tmp/libuninameslist/tests'
make: *** [Makefile:706: install-recursive] Error 1
```
This is because `tests/Makefile.am` adds `.libs` to the LDADD lines which is not correct. Ideally the build system should not use the `.libs` directories directly as they are for internal `$(LIBTOOL)` usage. GNU libtool does not fail because it is a lot more permissive.

Please see this downstream issue: https://bugs.gentoo.org/779670